### PR TITLE
No packet marker or non CCSDS header is the default

### DIFF
--- a/src/spac_kit/parser/remove_non_ccsds_headers.py
+++ b/src/spac_kit/parser/remove_non_ccsds_headers.py
@@ -129,6 +129,8 @@ def strip_non_ccsds_headers(
     Remove all cases of non CCSDS headers which can occur in
     Europa-Clipper SDS inputs, mostly in test cases.
 
+    By default, we consider there is not packet non CCSDS packet markers or headers.
+
     @param filename: input binary filename
     @param is_bdsem: file coming from BDSEM, else RAW
     @param has_pkt_header:

--- a/src/spac_kit/parser/remove_non_ccsds_headers.py
+++ b/src/spac_kit/parser/remove_non_ccsds_headers.py
@@ -120,7 +120,10 @@ def start_sequence(seq):
 
 
 def strip_non_ccsds_headers(
-    file_handler, is_bdsem: bool, has_pkt_header: bool, has_json_header: bool
+    file_handler,
+    is_bdsem: bool = False,
+    has_pkt_header: bool = False,
+    has_json_header: bool = False,
 ):
     """
     Remove all cases of non CCSDS headers which can occur in

--- a/src/spac_kit/parser/test_utils.py
+++ b/src/spac_kit/parser/test_utils.py
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def compare(
     local_dir: str,
-    is_bdsem: bool,
-    has_pkt_header: bool,
-    has_json_header: bool,
+    is_bdsem: bool = False,
+    has_pkt_header: bool = False,
+    has_json_header: bool = False,
     create_output: bool = False,
     create_spreadsheet: bool = False,
 ):


### PR DESCRIPTION
So that non Europa-Clipper mission have a working example without worrying about these Euroap-Clipper specific headers.